### PR TITLE
Migration necessary for v201603

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject adworj "0.2.5-SNAPSHOT"
+(defproject adworj "0.3.0-SNAPSHOT"
   :description "Clojure library to ease interacting with the Google AdWords API"
   :url "https://github.com/uswitch/adworj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/data.csv "0.1.2"]
-                 [com.google.api-ads/ads-lib "2.11.0"]
-                 [com.google.api-ads/adwords-axis "2.11.0"]
+                 [com.google.api-ads/ads-lib "2.12.0"]
+                 [com.google.api-ads/adwords-axis "2.12.0"]
                  [clj-time "0.8.0"]
                  [joda-time "2.6"]])

--- a/src/adworj/reporting.clj
+++ b/src/adworj/reporting.clj
@@ -844,6 +844,9 @@
                                                               :coerceion coerce
                                                               :raw       existing-value}))))))))
 
+(defn remove-empty-cell-dashes [s]
+  (s/replace s #"^--$" ""))
+
 (defn records
   "reads records from the input stream. returns a lazy sequence of
   records. converts records into clojure maps with their attributes


### PR DESCRIPTION
this version is essentially fully compatable with v201601, all changes are internal to client

includes: 
shift includeZeroImpressions as header
handle new empty cell notation of double-dash "--" replace with nil
