### PR TITLE
upgrade to v201802 adwords api

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject adworj "0.4.1-SNAPSHOT"
+(defproject adworj "0.5.0-SNAPSHOT"
   :description "Clojure library to ease interacting with the Google AdWords API"
   :url "https://github.com/uswitch/adworj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/data.csv "0.1.2"]
-                 [com.google.api-ads/ads-lib "3.9.0"]
-                 [com.google.api-ads/adwords-axis "3.9.0"]
-                 [clj-time "0.8.0"]
-                 [joda-time "2.6"]])
+                 [org.clojure/data.csv "0.1.4"]
+                 [com.google.api-ads/ads-lib "3.12.0"]
+                 [com.google.api-ads/adwords-axis "3.12.0"]
+                 [clj-time "0.14.2"]
+                 [joda-time "2.9.9"]])

--- a/src/adworj/conversion.clj
+++ b/src/adworj/conversion.clj
@@ -3,7 +3,7 @@
             [clj-time.format :as tf]
             [clojure.set :as s]
             [clojure.string :as st])
-  (:import [com.google.api.ads.adwords.axis.v201705.cm ApiError RateExceededError ApiException OfflineConversionFeed OfflineConversionFeedReturnValue OfflineConversionFeedOperation OfflineConversionFeedServiceInterface ConversionTrackerCategory UploadConversion ConversionTrackerOperation ConversionTrackerServiceInterface Operator Selector]
+  (:import [com.google.api.ads.adwords.axis.v201802.cm ApiError RateExceededError ApiException OfflineConversionFeed OfflineConversionFeedReturnValue OfflineConversionFeedOperation OfflineConversionFeedServiceInterface ConversionTrackerCategory UploadConversion ConversionTrackerOperation ConversionTrackerServiceInterface Operator Selector]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]))
 
 

--- a/src/adworj/customer.clj
+++ b/src/adworj/customer.clj
@@ -1,18 +1,19 @@
 (ns adworj.customer
-  (:import [com.google.api.ads.adwords.axis.v201705.mcm CustomerServiceInterface]
+  (:import [com.google.api.ads.adwords.axis.v201802.mcm CustomerServiceInterface]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]))
 
-(defrecord Customer [company-name currency-code customer-id date-time-zone descriptive-name tracking-url-template test-account?])
+(defrecord Customer [currency-code customer-id date-time-zone descriptive-name tracking-url-template test-account?])
 
 (defn customer-service [adwords-session]
   (let [services (AdWordsServices. )]
     (.get services adwords-session CustomerServiceInterface)))
 
 (defn customer [customer-service]
-  (let [c (.getCustomers customer-service)]
-    (map->Customer {:company-name          (.getCompanyName c)
-                    :currency-code         (.getCurrencyCode c)
-                    :customer-id           (.getCustomerId c)
-                    :date-time-zone        (.getDateTimeZone c)
-                    :descriptive-name      (.getDescriptiveName c)
-                    :tracking-url-template (.getTrackingUrlTemplate c)})))
+  (let [customers (.getCustomers customer-service)]
+    (->> customers
+      (map (fn [c]
+             (map->Customer {:currency-code         (.getCurrencyCode c)
+                             :customer-id           (.getCustomerId c)
+                             :date-time-zone        (.getDateTimeZone c)
+                             :descriptive-name      (.getDescriptiveName c)
+                             :tracking-url-template (.getTrackingUrlTemplate c)}))))))

--- a/src/adworj/reporting.clj
+++ b/src/adworj/reporting.clj
@@ -6,14 +6,14 @@
             [clojure.set :as set]
             [clojure.java.io :as io]
             [clojure.string :as s])
-  (:import [com.google.api.ads.adwords.lib.jaxb.v201710 ReportDefinition ReportDefinitionReportType]
-           [com.google.api.ads.adwords.lib.jaxb.v201710 DownloadFormat]
-           [com.google.api.ads.adwords.lib.jaxb.v201710 DateRange Selector ReportDefinitionDateRangeType]
+  (:import [com.google.api.ads.adwords.lib.jaxb.v201802 ReportDefinition ReportDefinitionReportType]
+           [com.google.api.ads.adwords.lib.jaxb.v201802 DownloadFormat]
+           [com.google.api.ads.adwords.lib.jaxb.v201802 DateRange Selector ReportDefinitionDateRangeType]
            [com.google.api.ads.adwords.lib.client AdWordsSession]
            [com.google.api.ads.adwords.lib.client.reporting ReportingConfiguration$Builder]
            [com.google.api.client.auth.oauth2 Credential]
-           [com.google.api.ads.adwords.lib.utils.v201710 ReportDownloader DetailedReportDownloadResponseException]
-           [com.google.api.ads.adwords.axis.v201710.cm ReportDefinitionServiceInterface]
+           [com.google.api.ads.adwords.lib.utils.v201802 ReportDownloader DetailedReportDownloadResponseException]
+           ; [com.google.api.ads.adwords.axis.v201802.cm ReportDefinitionServiceInterface]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]
            [java.util.zip GZIPInputStream]))
 
@@ -168,7 +168,6 @@
   :average-pageviews                      {:name "AveragePageviews" :parse parse-double}
   :average-position                       {:name "AveragePosition" :parse parse-double}
   :average-time-on-site                   {:name "AverageTimeOnSite" :parse parse-double}
-  :bid-type                               "BidType"
   :bidding-strategy-id                    "BiddingStrategyId"
   :bidding-strategy-name                  "BiddingStrategyName"
   :bidding-strategy-type                  "BiddingStrategyType"
@@ -371,7 +370,6 @@
   :average-cpm                                     {:name "AverageCpm" :parse parse-long}
   :average-position                                {:name "AveragePosition" :parse parse-double}
   :bid-modifier                                    "BidModifier"
-  :bid-type                                        "BidType"
   :campaign-id                                     "CampaignId"
   :campaign-name                                   "CampaignName"
   :campaign-status                                 "CampaignStatus"
@@ -435,7 +433,6 @@
   :average-cpc                         "AverageCpc"
   :average-cpm                         "AverageCpm"
   :bid-modifier                        "BidModifier"
-  :bid-type                            "BidType"
   :campaign-id                         "CampaignId"
   :campaign-name                       "CampaignName"
   :campaign-status                     "CampaignStatus"
@@ -486,7 +483,6 @@
   :average-cpm                         {:name "AverageCpm" :parse parse-long}
   :average-position                    {:name "AveragePosition" :parse parse-double}
   :bid-modifier                        "BidModifier"
-  :bid-type                            "BidType"
   :campaign-id                         "CampaignId"
   :campaign-name                       "CampaignName"
   :campaign-status                     "CampaignStatus"

--- a/test/adworj/reporting_test.clj
+++ b/test/adworj/reporting_test.clj
@@ -2,8 +2,8 @@
   (:require [adworj.reporting :as r]
             [clj-time.format :as tf]
             [clojure.test :refer :all])
-  (:import [com.google.api.ads.adwords.lib.jaxb.v201710 ReportDefinitionDateRangeType]
-           [com.google.api.ads.adwords.lib.jaxb.v201710 ReportDefinitionReportType]))
+  (:import [com.google.api.ads.adwords.lib.jaxb.v201802 ReportDefinitionDateRangeType]
+           [com.google.api.ads.adwords.lib.jaxb.v201802 ReportDefinitionReportType]))
 
 (deftest report-specification-test
   (let [d (r/report-definition r/search-query-performance


### PR DESCRIPTION
checked migration docs and made necessary changes. largely unchanged, couple of field deletions in reporting

https://developers.google.com/adwords/api/docs/guides/migration/v201802
https://developers.google.com/adwords/api/docs/guides/migration/v201710
https://developers.google.com/adwords/api/docs/guides/migration/v201708