### PR TITLE
Updating Adwords API to V201809

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject adworj "0.5.0-SNAPSHOT"
+(defproject adworj "0.6.0-SNAPSHOT"
   :description "Clojure library to ease interacting with the Google AdWords API"
   :url "https://github.com/uswitch/adworj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.csv "0.1.4"]
-                 [com.google.api-ads/ads-lib "3.12.0"]
-                 [com.google.api-ads/adwords-axis "3.12.0"]
-                 [clj-time "0.14.2"]
-                 [joda-time "2.9.9"]])
+                 [com.google.api-ads/ads-lib "4.2.0"]
+                 [com.google.api-ads/adwords-axis "4.2.0"]
+                 [clj-time "0.15.1"]
+                 [joda-time "2.10.1"]])

--- a/src/adworj/conversion.clj
+++ b/src/adworj/conversion.clj
@@ -3,7 +3,7 @@
             [clj-time.format :as tf]
             [clojure.set :as s]
             [clojure.string :as st])
-  (:import [com.google.api.ads.adwords.axis.v201806.cm ApiError RateExceededError ApiException OfflineConversionFeed OfflineConversionFeedReturnValue OfflineConversionFeedOperation OfflineConversionFeedServiceInterface ConversionTrackerCategory UploadConversion ConversionTrackerOperation ConversionTrackerServiceInterface Operator Selector]
+  (:import [com.google.api.ads.adwords.axis.v201809.cm ApiError RateExceededError ApiException OfflineConversionFeed OfflineConversionFeedReturnValue OfflineConversionFeedOperation OfflineConversionFeedServiceInterface ConversionTrackerCategory UploadConversion ConversionTrackerOperation ConversionTrackerServiceInterface Operator Selector]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]))
 
 

--- a/src/adworj/conversion.clj
+++ b/src/adworj/conversion.clj
@@ -3,7 +3,7 @@
             [clj-time.format :as tf]
             [clojure.set :as s]
             [clojure.string :as st])
-  (:import [com.google.api.ads.adwords.axis.v201802.cm ApiError RateExceededError ApiException OfflineConversionFeed OfflineConversionFeedReturnValue OfflineConversionFeedOperation OfflineConversionFeedServiceInterface ConversionTrackerCategory UploadConversion ConversionTrackerOperation ConversionTrackerServiceInterface Operator Selector]
+  (:import [com.google.api.ads.adwords.axis.v201806.cm ApiError RateExceededError ApiException OfflineConversionFeed OfflineConversionFeedReturnValue OfflineConversionFeedOperation OfflineConversionFeedServiceInterface ConversionTrackerCategory UploadConversion ConversionTrackerOperation ConversionTrackerServiceInterface Operator Selector]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]))
 
 

--- a/src/adworj/customer.clj
+++ b/src/adworj/customer.clj
@@ -1,5 +1,5 @@
 (ns adworj.customer
-  (:import [com.google.api.ads.adwords.axis.v201802.mcm CustomerServiceInterface]
+  (:import [com.google.api.ads.adwords.axis.v201806.mcm CustomerServiceInterface]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]))
 
 (defrecord Customer [currency-code customer-id date-time-zone descriptive-name tracking-url-template test-account?])

--- a/src/adworj/customer.clj
+++ b/src/adworj/customer.clj
@@ -1,5 +1,5 @@
 (ns adworj.customer
-  (:import [com.google.api.ads.adwords.axis.v201806.mcm CustomerServiceInterface]
+  (:import [com.google.api.ads.adwords.axis.v201809.mcm CustomerServiceInterface]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]))
 
 (defrecord Customer [currency-code customer-id date-time-zone descriptive-name tracking-url-template test-account?])

--- a/src/adworj/reporting.clj
+++ b/src/adworj/reporting.clj
@@ -6,14 +6,14 @@
             [clojure.set :as set]
             [clojure.java.io :as io]
             [clojure.string :as s])
-  (:import [com.google.api.ads.adwords.lib.jaxb.v201802 ReportDefinition ReportDefinitionReportType]
-           [com.google.api.ads.adwords.lib.jaxb.v201802 DownloadFormat]
-           [com.google.api.ads.adwords.lib.jaxb.v201802 DateRange Selector ReportDefinitionDateRangeType]
+  (:import [com.google.api.ads.adwords.lib.jaxb.v201806 ReportDefinition ReportDefinitionReportType]
+           [com.google.api.ads.adwords.lib.jaxb.v201806 DownloadFormat]
+           [com.google.api.ads.adwords.lib.jaxb.v201806 DateRange Selector ReportDefinitionDateRangeType]
            [com.google.api.ads.adwords.lib.client AdWordsSession]
            [com.google.api.ads.adwords.lib.client.reporting ReportingConfiguration$Builder]
            [com.google.api.client.auth.oauth2 Credential]
-           [com.google.api.ads.adwords.lib.utils.v201802 ReportDownloader DetailedReportDownloadResponseException]
-           ; [com.google.api.ads.adwords.axis.v201802.cm ReportDefinitionServiceInterface]
+           [com.google.api.ads.adwords.lib.utils.v201806 ReportDownloader DetailedReportDownloadResponseException]
+           ; [com.google.api.ads.adwords.axis.v201806.cm ReportDefinitionServiceInterface]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]
            [java.util.zip GZIPInputStream]))
 
@@ -548,7 +548,6 @@
   :date                                "Date"
   :day-of-week                         "DayOfWeek"
   :device                              "Device"
-  :device-preference                   "DevicePreference"
   :end-time                            "EndTime"
   :external-customer-id                "ExternalCustomerId"
   :feed-id                             "FeedId"
@@ -562,7 +561,6 @@
   :placeholder-type                    "PlaceholderType"
   :primary-company-name                "PrimaryCompanyName"
   :quarter                             "Quarter"
-  :scheduling                          "Scheduling"
   :slot                                "Slot"
   :start-time                          "StartTime"
   :status                              "Status"

--- a/src/adworj/reporting.clj
+++ b/src/adworj/reporting.clj
@@ -6,14 +6,14 @@
             [clojure.set :as set]
             [clojure.java.io :as io]
             [clojure.string :as s])
-  (:import [com.google.api.ads.adwords.lib.jaxb.v201806 ReportDefinition ReportDefinitionReportType]
-           [com.google.api.ads.adwords.lib.jaxb.v201806 DownloadFormat]
-           [com.google.api.ads.adwords.lib.jaxb.v201806 DateRange Selector ReportDefinitionDateRangeType]
+  (:import [com.google.api.ads.adwords.lib.jaxb.v201809 ReportDefinition ReportDefinitionReportType]
+           [com.google.api.ads.adwords.lib.jaxb.v201809 DownloadFormat]
+           [com.google.api.ads.adwords.lib.jaxb.v201809 DateRange Selector ReportDefinitionDateRangeType]
            [com.google.api.ads.adwords.lib.client AdWordsSession]
            [com.google.api.ads.adwords.lib.client.reporting ReportingConfiguration$Builder]
            [com.google.api.client.auth.oauth2 Credential]
-           [com.google.api.ads.adwords.lib.utils.v201806 ReportDownloader DetailedReportDownloadResponseException]
-           ; [com.google.api.ads.adwords.axis.v201806.cm ReportDefinitionServiceInterface]
+           [com.google.api.ads.adwords.lib.utils.v201809 ReportDownloader DetailedReportDownloadResponseException]
+           ; [com.google.api.ads.adwords.axis.v201809.cm ReportDefinitionServiceInterface]
            [com.google.api.ads.adwords.axis.factory AdWordsServices]
            [java.util.zip GZIPInputStream]))
 

--- a/test/adworj/reporting_test.clj
+++ b/test/adworj/reporting_test.clj
@@ -2,8 +2,8 @@
   (:require [adworj.reporting :as r]
             [clj-time.format :as tf]
             [clojure.test :refer :all])
-  (:import [com.google.api.ads.adwords.lib.jaxb.v201806 ReportDefinitionDateRangeType]
-           [com.google.api.ads.adwords.lib.jaxb.v201806 ReportDefinitionReportType]))
+  (:import [com.google.api.ads.adwords.lib.jaxb.v201809 ReportDefinitionDateRangeType]
+           [com.google.api.ads.adwords.lib.jaxb.v201809 ReportDefinitionReportType]))
 
 (deftest report-specification-test
   (let [d (r/report-definition r/search-query-performance

--- a/test/adworj/reporting_test.clj
+++ b/test/adworj/reporting_test.clj
@@ -2,8 +2,8 @@
   (:require [adworj.reporting :as r]
             [clj-time.format :as tf]
             [clojure.test :refer :all])
-  (:import [com.google.api.ads.adwords.lib.jaxb.v201802 ReportDefinitionDateRangeType]
-           [com.google.api.ads.adwords.lib.jaxb.v201802 ReportDefinitionReportType]))
+  (:import [com.google.api.ads.adwords.lib.jaxb.v201806 ReportDefinitionDateRangeType]
+           [com.google.api.ads.adwords.lib.jaxb.v201806 ReportDefinitionReportType]))
 
 (deftest report-specification-test
   (let [d (r/report-definition r/search-query-performance


### PR DESCRIPTION
I believe this does everything we need to update adworj through v201806 up to v201809.
I'm struggling a little with a test environment, or seeing how this gets published for consumption by other projects at the moment to verify that everything still works fine, but I'll get this PR raised now as everything in turn will need amending to this new version in turn anyway.